### PR TITLE
Add Docker deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Docker build context exclusions
+node_modules
+.next
+.git
+.gitignore
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-store
+.env.local
+.env
+.env.*
+*.log
+prisma/dev.db
+Dockerfile.local

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,10 @@
+NODE_ENV=production
+PORT=3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+ADMIN_PASSWORD=change_me
+JWT_SECRET=replace_with_a_strong_secret
+
+DATABASE_URL=postgresql://shortlink:shortlink@postgres:5432/shortlink?schema=public
+REDIS_URL=redis://redis:6379
+MAXMIND_LICENSE_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Application
+NODE_ENV=production
+PORT=3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Authentication
+ADMIN_PASSWORD=change_me
+JWT_SECRET=replace_with_a_strong_secret
+
+# Database
+DATABASE_URL=postgresql://user:password@localhost:5432/shortlink?schema=public
+
+# Cache
+REDIS_URL=redis://localhost:6379
+
+# Optional GeoIP
+MAXMIND_LICENSE_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!.env.docker.example
 
 # vercel
 .vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,13 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable \
  && apt-get update \
  && apt-get install -y --no-install-recommends openssl \
+ && npm install -g typescript@5.9.2 \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
-COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/next.config.ts ./next.config.ts
 COPY --from=builder /app/prisma ./prisma

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+
+ARG NODE_VERSION=20.11.1
+
+FROM node:${NODE_VERSION}-slim AS base
+ENV PNPM_HOME=/pnpm
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json pnpm-lock.yaml .npmrc* ./
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build && pnpm prune --prod
+
+FROM node:${NODE_VERSION}-slim AS runner
+ENV NODE_ENV=production
+ENV PNPM_HOME=/pnpm
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends openssl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/next.config.ts ./next.config.ts
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/components.json ./components.json
+COPY --from=builder /app/postcss.config.mjs ./postcss.config.mjs
+COPY --from=builder /app/tsconfig.json ./tsconfig.json
+COPY --from=builder /app/CLAUDE.md ./CLAUDE.md
+COPY --from=builder /app/LICENSE ./LICENSE
+
+EXPOSE 3000
+ENV PORT=3000
+
+CMD ["pnpm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ WORKDIR /app
 
 FROM base AS deps
 COPY package.json pnpm-lock.yaml .npmrc* ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile \
+    && pnpm add -D typescript@5.9.2
 
 FROM base AS builder
 ENV NODE_ENV=production
@@ -31,7 +32,7 @@ WORKDIR /app
 
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
+COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/next.config.ts ./next.config.ts
 COPY --from=builder /app/prisma ./prisma

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,298 @@
+# Short Link Tracker
+
+A comprehensive URL shortening service built with Next.js 15, featuring URL shortening, click tracking, and comprehensive data analytics.
+
+## Features
+
+- **URL Shortening**: Convert long URLs into short, shareable links
+- **Custom Short Codes**: Option to create custom short codes
+- **Advanced Link Management**: Add titles, tags, expiration dates, and click limits
+- **Table Sorting**: Sort links by various criteria (date, clicks, tags, etc.)
+- **Click Tracking**: Detailed click data tracking and analytics
+- **Analytics Dashboard**: View click trends, sources, device types, and geographical data (country detection is optional)
+- **QR Code Generation**: Generate customizable QR codes with logo upload support
+- **CSV Export**: Export analytics data for external analysis
+- **Custom 404 Pages**: Customize 404 page content and branding
+- **Admin Authentication**: Secure admin panel with "Remember Me" functionality
+- **Settings Management**: Centralized personalization configuration
+- **Modern Interface**: Built with shadcn/ui components and Tailwind CSS (Traditional Chinese)
+
+## Tech Stack
+
+- **Framework**: Next.js 15 with App Router
+- **Database**: PostgreSQL with Prisma ORM
+- **Cache**: Redis for performance optimization
+- **UI**: Tailwind CSS + shadcn/ui components
+- **Charts**: Recharts for data visualization
+- **QR Codes**: qr-code-styling with high customization support
+- **Authentication**: JWT with secure HTTP-only cookies
+- **File Upload**: Custom image processing for logos
+- **Geolocation**: MaxMind GeoLite2 for accurate country detection
+
+## Quick Start
+
+### 🚀 One-Click Deploy (Recommended)
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://goto.ray-realms.com/short-link-zeabur)
+
+Click the button above to deploy using Zeabur template with automatic PostgreSQL and Redis setup!
+
+---
+
+### 🏗️ Self-Deploy
+
+#### 📋 Prerequisites
+- Node.js 18+ 
+- pnpm package manager
+- PostgreSQL database
+- Redis cache service
+
+#### 🔧 Deployment Steps
+
+1. **Download and Install Dependencies**
+   ```bash
+   git clone <repository-url>
+   cd short-link-tracker
+   pnpm install
+   ```
+
+2. **Configure Environment Variables**
+   
+   Copy environment template:
+   ```bash
+   cp .env.example .env
+   ```
+   
+   Edit the `.env` file and set the following variables:
+
+   | Environment Variable | Description | Example Value |
+   |---------------------|-------------|---------------|
+   | `DATABASE_URL` | **Required** PostgreSQL connection string | `postgresql://user:pass@localhost:5432/shortlink` |
+   | `REDIS_URL` | **Required** Redis connection string | `redis://localhost:6379` |
+   | `ADMIN_PASSWORD` | **Required** Admin password | `your_secure_password` |
+   | `JWT_SECRET` | **Required** JWT signing key (recommended 32+ characters) | `your-super-secret-jwt-key-here` |
+   | `MAXMIND_LICENSE_KEY` | **Optional** MaxMind geolocation license key for identifying visitor countries by IP | `your_maxmind_key` |
+
+   > 💡 **MaxMind Note**: This service uses MaxMind's free GeoLite2 database to convert visitor IP addresses to country information, allowing you to see geographical distribution in analytics reports. MaxMind is completely free - if you don't need visitor country data, you can leave this blank.
+
+3. **Build the Application**
+   ```bash
+   pnpm build
+   ```
+
+4. **Start Production Server**
+   ```bash
+   pnpm start
+   ```
+
+   🎉 **Deployment Complete!** Your short link service is now live
+
+### 🐳 Docker Deployment
+
+Follow these steps to run the project with Docker:
+
+1. **Prepare Environment Variables**
+
+   Copy the Docker example file and adjust values as needed:
+   ```bash
+   cp .env.docker.example .env.docker
+   ```
+
+2. **Build the Docker Image**
+
+   The Dockerfile mirrors the manual deployment flow by running `pnpm build` followed by `pnpm start` in production mode:
+   ```bash
+   docker build -t short-link-tracker .
+   ```
+
+3. **Run with Docker Compose**
+
+   A ready-to-use `docker-compose.yml` file is provided. It spins up the application together with PostgreSQL and Redis on an isolated bridge network:
+   ```bash
+   docker compose up -d
+   ```
+
+   View the logs with:
+   ```bash
+   docker compose logs -f app
+   ```
+
+   Stop the stack with:
+   ```bash
+   docker compose down
+   ```
+
+The application will be available at http://localhost:3000 once all services are healthy.
+
+#### 🌍 Geolocation Setup (Optional)
+
+> 💡 **Note**: This feature is completely optional and doesn't affect normal application operation
+
+To display visitor country information in analytics:
+
+1. **Get MaxMind Free License Key**
+   - Go to https://www.maxmind.com/en/geolite2/signup and register for a free account
+   - Generate a license key in the dashboard
+   - Add the key to your `.env` file: `MAXMIND_LICENSE_KEY=your_license_key`
+
+2. **Update Geolocation Database**
+   ```bash
+   # Use convenience script to update
+   pnpm update-geoip
+   ```
+
+**When geolocation is not configured**:
+- ✅ Application works normally
+- 📍 Country field shows "Unknown"
+- 💬 Setup instructions displayed in console on first query
+
+---
+
+### 🛠️ Development Environment Setup
+
+For local development, follow these steps:
+
+```bash
+# Start Prisma development environment (automatically sets up PostgreSQL)
+npx prisma dev
+
+# Apply database migrations
+npx prisma migrate dev --name init
+
+# Start development server
+pnpm dev
+```
+
+Development environment will run at http://localhost:3000
+
+## Usage
+
+### 🔗 Application Entry Points
+- **Homepage**: `http://localhost:3000`
+- **Admin Panel**: `http://localhost:3000/admin`
+
+### 👤 Admin Panel Login
+- Use the `ADMIN_PASSWORD` set in your `.env` file (default: "admin123")
+- Check "Remember Me" to extend login duration (1 year)
+
+### ✨ Creating Short URLs
+1. Enter target URL in admin dashboard
+2. Optional settings:
+   - 🏷️ Custom short code
+   - 📝 Title and tags
+   - ⏰ Expiration date
+   - 🔢 Click limit
+3. Generate customizable QR codes
+4. Copy and share the generated short URL
+
+### 📊 Link Management
+- **Sorting**: Sort by title, tags, clicks, creation date, last click, or expiration
+- **Quick Toggle**: Click table headers to toggle ascending/descending order
+- **Status Indicators**: View complete link information and status indicators
+
+### 📈 Analytics Data
+- Click the "Analytics" button for any short URL
+- View 7-day or 30-day click trends
+- Check popular sources, device distribution, and geographical data
+- Country data (requires GeoIP setup, otherwise shows "Unknown")
+- Export CSV for external analysis
+
+### ⚙️ Custom Settings
+- Upload logos for QR codes and 404 pages
+- Set default QR code style preferences
+- Personalize 404 page content and appearance
+
+### 🎯 Short URL Usage
+- Visit `http://localhost:3000/{short-code}` to redirect to target URL
+- Each visit automatically tracks and records analytics data
+
+## API Endpoints
+
+### Authentication
+- `POST /api/auth/login` - Admin login
+- `POST /api/auth/logout` - Admin logout
+- `GET /api/auth/check` - Check authentication status
+
+### Link Management
+- `GET /api/links` - Get all short links with sorting support (requires auth)
+- `POST /api/links` - Create new short link with advanced options (requires auth)
+- `GET /api/links/[id]/analytics` - Get link analytics data (requires auth)
+- `GET /api/links/[id]/export` - Export analytics data as CSV (requires auth)
+
+### Settings Management
+- `GET /api/settings` - Get admin settings (requires auth)
+- `PUT /api/settings` - Update settings (requires auth)
+- `GET /api/settings/public` - Get public settings for 404 pages
+
+### URL Redirection
+- `GET /[slug]` - Redirect to target URL and track clicks
+
+## Database Schema
+
+### Links Table
+- `id`: Unique identifier
+- `slug`: URL short code
+- `target_url`: Original long URL
+- `title`: Optional description title
+- `tag`: Group/category tag
+- `expires_at`: Optional expiration date
+- `click_limit`: Optional maximum click limit
+- `last_click_at`: Last click timestamp
+- `created_at`: Creation timestamp
+- `updated_at`: Last update timestamp
+
+### Clicks Table
+- `id`: Unique identifier
+- `link_id`: Links table reference
+- `timestamp`: Click timestamp
+- `referrer`: HTTP referrer header
+- `user_agent`: Browser user agent
+- `device`: Device type (desktop/mobile/tablet, etc.)
+- `country`: ISO 3166-1 country code (if GeoIP is configured)
+
+### Settings Table
+- `id`: Unique identifier
+- `logo_url`: Uploaded logo image URL
+- `default_qr_style`: Default QR code style (square/rounded/dots)
+- `custom_404_title`: Custom 404 page title
+- `custom_404_description`: Custom 404 page description
+- `custom_404_button_text`: Custom 404 page button text
+- `custom_404_button_url`: Custom 404 page button URL
+- `created_at`: Creation timestamp
+- `updated_at`: Last update timestamp
+
+## Security Features
+
+- 🔐 Password-based admin authentication
+- 🎫 Configurable expiration JWT tokens
+- 🍪 HTTP-only secure cookie settings
+- 🛡️ SameSite Cookie CSRF protection
+- ✅ Input validation and sanitization
+- 💉 Prisma ORM SQL injection protection
+
+## Performance Optimizations
+
+- ⚡ Redis caching for frequently accessed data
+- 🔍 Database indexes on commonly queried fields
+- 🔄 Asynchronous click tracking to avoid redirect blocking
+- 📄 Static page generation where possible
+- 📦 Tree shaking for optimized bundle size
+
+## Deployment Options
+
+This application can be deployed on any platform that supports Node.js:
+
+- **Vercel**: Zero-configuration deployment with built-in PostgreSQL and Redis
+- **Railway**: Easy deployment with database add-ons
+- **Docker**: Containerized deployment using included Dockerfile
+- **Traditional Hosting**: Deploy to VPS with PostgreSQL and Redis instances
+
+## Support & Issues
+
+If you encounter any issues or have suggestions, feel free to join our Discord community for discussion:
+
+[![Discord](https://img.shields.io/badge/Discord-7289DA?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/fH8BxMWaYb)
+
+## License
+
+MIT License - see LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -84,8 +84,45 @@
    ```bash
    pnpm start
    ```
-   
+
    🎉 **部署完成！** 您的短網址服務現已上線
+
+### 🐳 使用 Docker 部署
+
+依照以下步驟透過 Docker 執行專案：
+
+1. **準備環境變數**
+
+   複製 Docker 環境範本後依需求調整：
+   ```bash
+   cp .env.docker.example .env.docker
+   ```
+
+2. **建立 Docker 映像檔**
+
+   Dockerfile 會在建置流程中執行與自行部署相同的 `pnpm build` 及 `pnpm start` 指令：
+   ```bash
+   docker build -t short-link-tracker .
+   ```
+
+3. **透過 docker-compose 執行**
+
+   專案內附的 `docker-compose.yml` 會在獨立的 bridge 網路中啟動應用程式、PostgreSQL 與 Redis：
+   ```bash
+   docker compose up -d
+   ```
+
+   查看應用程式日誌：
+   ```bash
+   docker compose logs -f app
+   ```
+
+   停止整個服務：
+   ```bash
+   docker compose down
+   ```
+
+全部服務啟動後即可在 http://localhost:3000 造訪應用程式。
 
 #### 🌍 地理位置功能設定（可選）
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,6 @@ services:
   redis:
     image: redis:7-alpine
     command: redis-server --appendonly yes
-    sysctls:
-      - vm.overcommit_memory=1
     volumes:
       - redis-data:/data
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env.docker
+    ports:
+      - "3000:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    networks:
+      - shortlink-network
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: shortlink
+      POSTGRES_PASSWORD: shortlink
+      POSTGRES_DB: shortlink
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - shortlink-network
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - redis-data:/data
+    networks:
+      - shortlink-network
+
+volumes:
+  postgres-data:
+  redis-data:
+
+networks:
+  shortlink-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
   redis:
     image: redis:7-alpine
     command: redis-server --appendonly yes
+    sysctls:
+      - vm.overcommit_memory=1
     volumes:
       - redis-data:/data
     networks:


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that mirrors the pnpm build/start workflow
- provide docker-compose orchestration with PostgreSQL and Redis plus env templates
- document Docker-based deployment in both English and Chinese READMEs

## Testing
- docker build -t short-link-tracker:test . *(fails: docker CLI unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ec73a56c833191b6f92cf2273f86