### PR TITLE
Ensure TypeScript is available at runtime Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,13 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable \
  && apt-get update \
  && apt-get install -y --no-install-recommends openssl \
+ && npm install -g typescript@5.9.2 \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
-COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/next.config.ts ./next.config.ts
 COPY --from=builder /app/prisma ./prisma

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ WORKDIR /app
 
 FROM base AS deps
 COPY package.json pnpm-lock.yaml .npmrc* ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile \
+    && pnpm add -D typescript@5.9.2
 
 FROM base AS builder
 ENV NODE_ENV=production
@@ -31,7 +32,7 @@ WORKDIR /app
 
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
+COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/next.config.ts ./next.config.ts
 COPY --from=builder /app/prisma ./prisma

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,6 @@ services:
   redis:
     image: redis:7-alpine
     command: redis-server --appendonly yes
-    sysctls:
-      - vm.overcommit_memory=1
     volumes:
       - redis-data:/data
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
   redis:
     image: redis:7-alpine
     command: redis-server --appendonly yes
+    sysctls:
+      - vm.overcommit_memory=1
     volumes:
       - redis-data:/data
     networks:


### PR DESCRIPTION
## Summary
- install TypeScript as a dev dependency during dependency stage so it remains available at runtime
- copy runtime node_modules from the deps stage and add Redis sysctl configuration for docker compose

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70a2ecc1c833188ac73221c21f99f